### PR TITLE
Add support for storing comments created by Zendesk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,12 @@ common: &common
         name: upload coverage report
         command: |
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
+              bash <(curl -s https://codecov.io/bash) -s coverage -d > upload.txt
               bash <(curl -s https://codecov.io/bash) -s coverage
+              #PATH=$HOME/.local/bin:$PATH
+              #pip install --user codecov
+              #coverage xml
+              #~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
           fi
     - save_cache:
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ common: &common
         name: upload coverage report
         command: |
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
-              coverage xml
               bash <(curl -s https://codecov.io/bash)
           fi
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,10 +18,7 @@ common: &common
         name: upload coverage report
         command: |
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
-              PATH=$HOME/.local/bin:$PATH
-              pip install --user codecov
-              coverage xml
-              ~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
+              bash <(curl -s https://codecov.io/bash) -s coverage
           fi
     - save_cache:
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,13 @@ common: &common
     - run:
         name: upload coverage report
         command: |
+          ls
+          pwd
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
-              bash <(curl -s https://codecov.io/bash) -s coverage -d > upload.txt
-              bash <(curl -s https://codecov.io/bash) -s coverage
               #PATH=$HOME/.local/bin:$PATH
-              #pip install --user codecov
-              #coverage xml
+              pip install --user codecov
+              coverage xml
+              bash <(curl -s https://codecov.io/bash)
               #~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
           fi
     - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ common: &common
         name: upload coverage report
         command: |
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
-              pip install --user codecov
               coverage xml
               bash <(curl -s https://codecov.io/bash)
           fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,14 +17,10 @@ common: &common
     - run:
         name: upload coverage report
         command: |
-          ls -la
-          pwd
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
-              #PATH=$HOME/.local/bin:$PATH
               pip install --user codecov
               coverage xml
               bash <(curl -s https://codecov.io/bash)
-              #~/.local/bin/codecov --required -X search gcov pycov -f coverage.xml --flags $CIRCLE_JOB
           fi
     - save_cache:
         paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ common: &common
     - run:
         name: upload coverage report
         command: |
-          ls
+          ls -la
           pwd
           if [[ "$UPLOAD_COVERAGE" != 0 ]]; then
               #PATH=$HOME/.local/bin:$PATH

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    version="1.2.0",
+    version="1.3.0",
     license="MIT",
     url=url,
     packages=find_packages(exclude=["tests", "testproj"]),

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -610,6 +610,99 @@ two_comments_with_attachments = json.loads(
   """
 )
 
+
+comment_with_no_author = json.loads(
+    r"""{
+  "comments": [
+    {
+      "id": 1,
+      "type": "Comment",
+      "author_id": 1,
+      "body": "Last message to the customer was a notification",
+      "html_body": "<div class=\"zd-comment\" dir=\"auto\">Last message to the customer was a notification</div>",
+      "plain_body": "Last message to the customer was a notification",
+      "public": false,
+      "attachments": [],
+      "audit_id": 1,
+      "via": {
+        "channel": "sms",
+        "source": {
+          "from": {},
+          "to": {},
+          "rel": null
+        }
+      },
+      "created_at": "2019-08-01T19:22:21Z",
+      "metadata": {
+        "system": {
+          "client": "",
+          "ip_address": ""
+        },
+        "custom": {}
+      }
+    },
+    {
+      "id": 2,
+      "type": "Comment",
+      "author_id": -1,
+      "body": "Last message to the customer was a notification",
+      "html_body": "<div class=\"zd-comment\" dir=\"auto\">Last message to the customer was a notification</div>",
+      "plain_body": "Last message to the customer was a notification",
+      "public": false,
+      "attachments": [],
+      "audit_id": 2,
+      "via": {
+        "channel": "sms",
+        "source": {
+          "from": {},
+          "to": {},
+          "rel": null
+        }
+      },
+      "created_at": "2019-08-01T19:29:10Z",
+      "metadata": {
+        "system": {
+          "client": "",
+          "ip_address": ""
+        },
+        "custom": {}
+      }
+    },
+    {
+      "id": 3,
+      "type": "Comment",
+      "author_id": 2,
+      "body": "Ho hum",
+      "html_body": "<div class=\"zd-comment\" dir=\"auto\">Ho hum</div>",
+      "plain_body": "Ho hum",
+      "public": false,
+      "attachments": [],
+      "audit_id": 3,
+      "via": {
+        "channel": "sms",
+        "source": {
+          "from": {},
+          "to": {},
+          "rel": null
+        }
+      },
+      "created_at": "2019-08-01T19:30:29Z",
+      "metadata": {
+        "system": {
+          "client": "",
+          "ip_address": ""
+        },
+        "custom": {}
+      }
+    }
+  ],
+  "next_page": null,
+  "previous_page": null,
+  "count": 3
+}"""
+)
+
+
 search_one_result = json.loads(
     r"""{
   "results": [

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1107,3 +1107,7 @@ def test_get_special_zendesk_user():
     assert user.zendesk_id == -1
     assert user.name == "Zendesk"
     assert user.role.admin
+
+    # and it will only be created once
+    user_2 = service.ZengoService().get_special_zendesk_user()
+    assert user.id == user_2.id

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -969,7 +969,10 @@ def test_sync_ticket_with_attachments():
     local = local_comments[0].attachments.all()[0]
 
     assert local.zendesk_id == 365674118331
-    assert local.file_name == "IMG_20190101_001154-some-really-ridiculously-long-file-name-how-could-people-bring-themselves-to-be-this-verbose-but-really-how-and-what-is-it-they-hoped-to-achieve-is-it-world-domination-or-an-abomination-foos.jpg"
+    assert (
+        local.file_name
+        == "IMG_20190101_001154-some-really-ridiculously-long-file-name-how-could-people-bring-themselves-to-be-this-verbose-but-really-how-and-what-is-it-they-hoped-to-achieve-is-it-world-domination-or-an-abomination-foos.jpg"
+    )
     assert (
         local.content_url
         == "https://example.zendesk.com/attachments/token/jFGBxOznWMG8lWRXUt0DAi1UQ/?name=IMG_20190101_001154-some-really-ridiculously-long-file-name-how-could-people-bring-themselves-to-be-this-verbose-but-really-how-and-what-is-it-they-hoped-to-achieve-is-it-world-domination-or-an-abomination-foos.jpg"
@@ -1076,3 +1079,31 @@ def test_sync_ticket_with_voice_comment():
 
     # no plain_body is available
     assert local_comments[0].plain_body is None
+
+
+@responses.activate
+@pytest.mark.django_db
+def test_sync_ticket_with_comment_with_no_author():
+    # when a comment on a ticket has an author value of `-1`, this is
+    # Zendesk adding a comment usually to do with some ticket merging
+    # As these messages have mostly low-value to users, we just skip
+    # them for now.
+    add_api_responses(comments=api_responses.comment_with_no_author)
+
+    local_ticket, created = service.ZengoService().sync_ticket_id(1)
+
+    local_comments = local_ticket.comments.all()
+    assert local_comments.count() == 3
+    assert local_comments[0].author.zendesk_id == 1
+    assert local_comments[1].author.zendesk_id == -1
+    assert not local_comments[1].public
+    assert local_comments[2].author.zendesk_id == 2
+
+
+@responses.activate
+@pytest.mark.django_db
+def test_get_special_zendesk_user():
+    user = service.ZengoService().get_special_zendesk_user()
+    assert user.zendesk_id == -1
+    assert user.name == "Zendesk"
+    assert user.role.admin

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
 commands =
     coverage run -m pytest tests/tests.py {posargs}
-    coverage report -m --skip-covered
+    bash <(curl -s https://codecov.io/bash)
 
 [testenv:checkqa]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -40,8 +40,8 @@ passenv =
 
 # we assume use of semantic versioning on deps
 deps =
-    coverage>=4,<5
-    pytest>=4,<5
+    coverage
+    codecov
     pytest-django>=3,<4
     pytest-mock>=1,<2
     django-allauth>=0.37.0,<1

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ passenv =
 # we assume use of semantic versioning on deps
 deps =
     coverage>=4,<5
-    codecov>=2,<3
     pytest>=4,<5
     pytest-django>=3,<4
     pytest-mock>=1,<2

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ setenv =
     DJANGO_SETTINGS_MODULE=tests.settings
 commands =
     coverage run -m pytest tests/tests.py {posargs}
-    bash <(curl -s https://codecov.io/bash)
+    coverage report -m --skip-covered
 
 [testenv:checkqa]
 commands =


### PR DESCRIPTION
When the author ID on a comment is -1, it represents Zendesk, not an actual user. This PR fixes syncing comments authored by Zendesk.