### PR TITLE
Add alias support to the ZendeskUser model.

### DIFF
--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -788,6 +788,7 @@ create_user_result = json.loads(
   "user": {
       "id": 1,
       "name": "Monica",
+      "alias": "Billy",
       "email": "monica@example.com",
       "created_at": "2019-01-10T22:06:54Z",
       "updated_at": "2019-01-11T00:01:37Z",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -849,6 +849,7 @@ def test_sync_user():
 
     assert local_zd_user.zendesk_id == remote.id
     assert local_zd_user.email == remote.email
+    assert local_zd_user.alias == remote.alias
     # user should be found and linked
     assert local_zd_user.user == user
     assert local_zd_user.created_at == remote.created_at

--- a/zengo/migrations/0004_zendeskuser_alias.py
+++ b/zengo/migrations/0004_zendeskuser_alias.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("zengo", "0003_relax_url_maxlength"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="zendeskuser",
+            name="alias",
+            field=models.TextField(blank=True, null=True),
+        ),
+    ]

--- a/zengo/models.py
+++ b/zengo/models.py
@@ -36,6 +36,7 @@ class ZendeskUser(models.Model):
     zendesk_id = models.BigIntegerField(unique=True)
 
     name = models.TextField(null=True, blank=True)
+    alias = models.TextField(null=True, blank=True)
     email = models.EmailField(null=True, blank=True)
     active = models.BooleanField(default=True)
     # we store all of the photo details from the API as JSON encoded text

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -119,9 +119,10 @@ class ZengoService(object):
             print(a.response.json())
             details = a.response.json()["details"]
             if any([d[0]["error"] == "DuplicateValue" for d in details.values()]):
-                remote_zd_user, is_definite_match = self.get_remote_zd_user_for_local_user(
-                    local_user
-                )
+                (
+                    remote_zd_user,
+                    is_definite_match,
+                ) = self.get_remote_zd_user_for_local_user(local_user)
             else:
                 raise
         return remote_zd_user
@@ -207,6 +208,7 @@ class ZengoService(object):
             defaults=dict(
                 # attempt to resolve the local user if possible
                 user=self.get_local_user_for_external_id(remote_zd_user.external_id),
+                alias=remote_zd_user.alias,
                 email=remote_zd_user.email,
                 created_at=remote_zd_user.created_at,
                 name=remote_zd_user.name,


### PR DESCRIPTION
- Add a new field `alias` to the ZendeskUser model.
- Updated the `ZengoService.sync_user` to bring over the `alias` from Zendesk.
- Update the tests.