### PR TITLE
Fix Ticket admin search fields to be fields from the model

### DIFF
--- a/zengo/admin.py
+++ b/zengo/admin.py
@@ -37,7 +37,7 @@ class TicketAdmin(admin.ModelAdmin):
     raw_id_fields = ["requester"]
     # for Django >=2.1
     autocomplete_fields = ["requester"]
-    search_fields = ["ticket__subject", "ticket__zendesk_id"]
+    search_fields = ["subject", "zendesk_id"]
 
     def get_queryset(self, request):
         return models.Ticket.objects.all().select_related("requester")


### PR DESCRIPTION
The Ticket admin will 500 if you search on the list view.

```
Request Method: | GET
-- | --
https://localhost:8888/admin/zengo/ticket/?q=abc
2.2.10
FieldError
Cannot resolve keyword 'ticket' into field. Choices are: comments, created_at, custom_fields, events, id, priority, requester, requester_id, status, subject, tags, updated_at, url, zendesk_id
/usr/local/lib/python3.7/site-packages/django/db/models/sql/query.py in names_to_path, line 1420
/usr/local/bin/python
3.7.7
['/app',  '/usr/local/lib/python37.zip',  '/usr/local/lib/python3.7',  '/usr/local/lib/python3.7/lib-dynload',  '/usr/local/lib/python3.7/site-packages']
Tue, 9 Jun 2020 03:34:58 +0000
```