### PR TITLE
Added handling of some exception situations when fetching or updating the remote Zendesk user

### DIFF
--- a/zengo/exception.py
+++ b/zengo/exception.py
@@ -1,0 +1,2 @@
+class ZengoException(Exception):
+    pass

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -176,11 +176,9 @@ class ZengoService(object):
             try:
                 remote_zd_user = self.client.users.update(remote_zd_user)
             except APIException as exc:
-                logger.error(
-                    "Failed to update remote ZD user. Error: %s " % exc)
-                # Even if the email changed above, we failed to update it here
-                # so we should not be doing the next step for email_changed
-                return
+                raise ZengoException("Failed to update remote ZD user for "
+                                     "local user %s. Error: %s " % (local_user,
+                                                                    exc))
 
         if email_changed:
             # then in addition to the above, we have to mark the newly

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -173,7 +173,14 @@ class ZengoService(object):
             email_changed = True
 
         if changed:
-            remote_zd_user = self.client.users.update(remote_zd_user)
+            try:
+                remote_zd_user = self.client.users.update(remote_zd_user)
+            except APIException as exc:
+                logger.error(
+                    "Failed to update remote ZD user. Error: %s " % exc)
+                # Even if the email changed above, we failed to update it here
+                # so we should not be doing the next step for email_changed
+                email_changed = False
 
         if email_changed:
             # then in addition to the above, we have to mark the newly

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -18,6 +18,7 @@ from zenpy.lib.api_objects import User as RemoteZendeskUser
 from zenpy.lib.exception import APIException
 
 from . import models, signals, strings
+from .exception import ZengoException
 from .settings import app_settings
 
 
@@ -186,9 +187,15 @@ class ZengoService(object):
                     break
 
     def update_or_create_remote_zd_user(self, local_user):
-        remote_zd_user, is_definite_match = self.get_remote_zd_user_for_local_user(
-            local_user
-        )
+        try:
+            remote_zd_user, is_definite_match = \
+                self.get_remote_zd_user_for_local_user(
+                    local_user
+                )
+        except APIException as exc:
+            raise ZengoException("Failed to query remote Zendesk user for local"
+                                 "user %s. Error: %s" % (local_user, exc))
+
         if remote_zd_user and is_definite_match:
             # check if we need to do any updates
             self.update_remote_zd_user_for_local_user(local_user, remote_zd_user)

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -122,7 +122,8 @@ class ZengoService(object):
                     is_definite_match,
                 ) = self.get_remote_zd_user_for_local_user(local_user)
             else:
-                raise
+                raise ZengoException("Failed to create remote Zendesk user for "
+                                     "local user %s. Error: %s" % (local_user, a))
         return remote_zd_user
 
     def get_or_create_remote_zd_user_for_local_user(self, local_user):

--- a/zengo/service.py
+++ b/zengo/service.py
@@ -180,7 +180,7 @@ class ZengoService(object):
                     "Failed to update remote ZD user. Error: %s " % exc)
                 # Even if the email changed above, we failed to update it here
                 # so we should not be doing the next step for email_changed
-                email_changed = False
+                return
 
         if email_changed:
             # then in addition to the above, we have to mark the newly


### PR DESCRIPTION
Introduced a `ZengoException` and we are re-raising that with more informative error messages that fit the abstraction level of the Zengo library instead of the underlying client library. This way the callers of Zengo don't need to know about the underlying client library for exception handling and also we get more useful error messages.